### PR TITLE
Liven up map styles (and some UI, too)

### DIFF
--- a/source/Canvas.js
+++ b/source/Canvas.js
@@ -68,15 +68,9 @@ class Canvas {
     return this._mapGraphic
   }
 
-  _setCanvasAttribute(canvas, key, value) {
-    const attribute = document.createAttribute(key)
-    attribute.value = value
-    canvas.setAttributeNode(attribute)
-  }
-
   resize() {
-    this._setCanvasAttribute(this._canvas, 'width', canvasDimensions.width)
-    this._setCanvasAttribute(this._canvas, 'height', canvasDimensions.height)
+    this._canvas.width = canvasDimensions.width
+    this._canvas.height = canvasDimensions.height
     this._canvas.style.width = `${canvasDimensions.width / devicePixelRatio}px`
   }
 

--- a/source/Canvas.js
+++ b/source/Canvas.js
@@ -72,6 +72,9 @@ class Canvas {
     this._canvas.width = canvasDimensions.width
     this._canvas.height = canvasDimensions.height
     this._canvas.style.width = `${canvasDimensions.width / devicePixelRatio}px`
+    if (this._gridGraphic) {
+      this._gridGraphic.renderBackgroundImage()
+    }
   }
 
   _createCanvas() {

--- a/source/Ui.js
+++ b/source/Ui.js
@@ -231,14 +231,16 @@ class Ui {
             />
           </div>
           <div className='no-scroll-ui'>
-            <ExportButton
-              text='Export Svg'
-              onClick={() => this._exportSvgCallback()}
-            />
-            <ExportButton
-              text='Export TopoJSON'
-              onClick={() => this._exportCallback()}
-            />
+            <fieldset>
+              <ExportButton
+                text='Export TopoJSON'
+                onClick={() => this._exportCallback()}
+              />
+              <ExportButton
+                text='Export Svg'
+                onClick={() => this._exportSvgCallback()}
+              />
+            </fieldset>
           </div>
         </div>
         <h2 className='credits'>

--- a/source/components/ExportButton.js
+++ b/source/components/ExportButton.js
@@ -2,11 +2,9 @@ import React from 'react'
 
 export default function ExportButton(props) {
   return (
-    <fieldset>
-      <a className='export' onClick={props.onClick}>
-        {props.text}
-      </a>
-    </fieldset>
+    <a className='export' onClick={props.onClick}>
+      {props.text}
+    </a>
   )
 }
 ExportButton.propTypes = {

--- a/source/constants.js
+++ b/source/constants.js
@@ -22,7 +22,6 @@ const nTileDomain = [80, 8000]
 class Settings {
   constructor() {
     this.tileScale = 0.95
-    this.hueScalar = 5
     this.displayMap = true
     this.displayGrid = true
   }
@@ -30,7 +29,6 @@ class Settings {
 const settings = new Settings()
 const gui = new dat.GUI()
 gui.add(settings, 'tileScale', 0.9, 1.0)
-gui.add(settings, 'hueScalar', 1, 10)
 gui.add(settings, 'displayMap')
 gui.add(settings, 'displayGrid')
 dat.GUI.toggleHide()

--- a/source/css/main.scss
+++ b/source/css/main.scss
@@ -2,7 +2,7 @@
 @import 'reset';
 
 $font-stack: 'Fira Sans', sans-serif;
-$sidebar-width: 280px;
+$sidebar-width: 320px;
 $blue: #5656f7;
 
 body {
@@ -214,12 +214,12 @@ fieldset {
     margin-bottom: 6px;
   }
   a.export {
+    display: inline-block;
     background-color: $blue;
     border-radius: 5px;
     padding: 0.5em 0.75em;
+    margin: 0 0.5em;
     color: white;
-    margin: 0;
-    font-size: 80%;
   }
   a.import {
     margin: 0;

--- a/source/css/main.scss
+++ b/source/css/main.scss
@@ -213,6 +213,9 @@ fieldset {
     width: $sidebar-width * 0.3;
     margin-bottom: 6px;
   }
+  select {
+    font-size: 125%;
+  }
   a.export {
     display: inline-block;
     background-color: $blue;

--- a/source/css/main.scss
+++ b/source/css/main.scss
@@ -90,7 +90,7 @@ a {
   .gnl-logo {
     display: inline-block;
     height: 1.2em;
-    margin-bottom: -3px;
+    margin-bottom: -4px;
   }
 }
 

--- a/source/geometry/GridGeometry.js
+++ b/source/geometry/GridGeometry.js
@@ -59,6 +59,10 @@ class GridGeometry {
     return shape.getDrawOffsetY(x)
   }
 
+  getTileCounts() {
+    return this._tileCounts
+  }
+
   resize() {
     this._tileSize = shape.getTileSize(this._tileEdge)
     const gridUnit = shape.getGridUnit()

--- a/source/geometry/GridGeometry.js
+++ b/source/geometry/GridGeometry.js
@@ -79,8 +79,8 @@ class GridGeometry {
   }
 
   forEachTilePosition(iterator) {
-    for (let x = TILE_OFFSET; x < this._tileCounts.width; x++) {
-      for (let y = TILE_OFFSET; y < this._tileCounts.height; y++) {
+    for (let x = TILE_OFFSET - 2; x < this._tileCounts.width + 3; x++) {
+      for (let y = TILE_OFFSET - 2; y < this._tileCounts.height + 3; y++) {
         iterator(x, y)
       }
     }

--- a/source/graphics/GridGraphic.js
+++ b/source/graphics/GridGraphic.js
@@ -423,7 +423,7 @@ export default class GridGraphic extends Graphic {
       this._ctx.textAlign = 'center'
       this._ctx.textBaseline = 'middle'
       this._ctx.fillStyle = 'black'
-      this._ctx.font = `${12.0 * devicePixelRatio}px Arial`
+      this._ctx.font = `${12.0 * devicePixelRatio}px Fira Sans`
       this._ctx.fillText(fipsToPostal(id), clusterAvg[0], clusterAvg[1])
     })
   }

--- a/source/graphics/GridGraphic.js
+++ b/source/graphics/GridGraphic.js
@@ -317,7 +317,7 @@ export default class GridGraphic extends Graphic {
     this.originalTilesLength = this._tiles.length
     this._hasBeenEdited = false // reset edit state
     this.updateUi()
-    this._renderBackgroundImage()
+    this.renderBackgroundImage()
     return this._tiles
   }
 
@@ -327,7 +327,7 @@ export default class GridGraphic extends Graphic {
     const maxY = Math.max(...tiles.map(tile => tile.position.y))
     gridGeometry.setTileEdgeFromMax(maxX, maxY)
     this._tiles = tiles
-    this._renderBackgroundImage()
+    this.renderBackgroundImage()
   }
 
   getTiles() {
@@ -352,7 +352,7 @@ export default class GridGraphic extends Graphic {
     return this._hasBeenEdited
   }
 
-  _renderBackgroundImage() {
+  renderBackgroundImage() {
     this._backgroundCanvas = document.createElement('canvas')
     this._backgroundCanvas.width = canvasDimensions.width
     this._backgroundCanvas.height = canvasDimensions.height

--- a/source/graphics/GridGraphic.js
+++ b/source/graphics/GridGraphic.js
@@ -129,6 +129,7 @@ export default class GridGraphic extends Graphic {
       }
 
       // determine where each tile is going to be moved to
+      const counts = gridGeometry.getTileCounts()
       const overlaps = this._selectedTiles.some((tile) => {
         // figure out where in XY space this tile currently is
         const tileXY = gridGeometry.tileCenterPoint(tile.position)
@@ -146,6 +147,13 @@ export default class GridGraphic extends Graphic {
             // bail, we are moving a tile to where a tile already exists.
             return true
           }
+        }
+        if (
+          tile.newPosition.x > (counts.width) ||
+          tile.newPosition.y > (counts.height)
+        ) {
+          // bail, we are moving offscreen
+          return true
         }
         return false
       })

--- a/source/resources/TilegramResource.js
+++ b/source/resources/TilegramResource.js
@@ -11,7 +11,7 @@ class TilegramResource {
         topoJson: pitchPopulationTilegram,
       },
       {
-        label: 'FiveThirtyEight Electoral College 2016',
+        label: 'FiveThirtyEight Electoral College',
         topoJson: fiveThirtyEightElectoralCollegeTilegram,
       },
       {

--- a/source/utils.js
+++ b/source/utils.js
@@ -4,7 +4,7 @@ import fipsHash from '../data/fips-to-state.json'
 function fipsColor(fips) {
   const number = parseInt(fips, 10)
   const scalar = number / 56.0
-  return `hsl(${360 - ((scalar * 180.0) + 180.0)}, 70%, 65%)`
+  return `hsl(${360 - ((scalar * 180.0) + 180.0)}, 85%, 70%)`
 }
 
 /** Create DOM element. Options may include 'id' */

--- a/source/utils.js
+++ b/source/utils.js
@@ -1,9 +1,10 @@
-import {settings} from './constants'
 import fipsHash from '../data/fips-to-state.json'
 
 /** Return a pseudo-random color for a given fips code */
 function fipsColor(fips) {
-  return `hsl(${parseInt(fips, 10) * (settings.hueScalar % 25.5) * 10.0}, 90%, 65%)`
+  const number = parseInt(fips, 10)
+  const scalar = number / 56.0
+  return `hsl(${360 - ((scalar * 180.0) + 180.0)}, 70%, 65%)`
 }
 
 /** Create DOM element. Options may include 'id' */


### PR DESCRIPTION
A few things going on here.

On the map:
- always draw inland borders between regions
- draw empty tiles in background (pre-rendered only on resolution changes)
- narrow hue band in color generation

In the UI:
- give Export buttons a bit more breathing room
- bump up font size on menus a bit

Plus some light code cleanup.

<img width="852" alt="screen shot 2016-09-19 at 5 42 22 pm" src="https://cloud.githubusercontent.com/assets/15598/18653691/739bd9a2-7e90-11e6-9e16-025f692399a1.png">
