### PR TITLE
Csv validate geos

### DIFF
--- a/source/components/HexMetrics.js
+++ b/source/components/HexMetrics.js
@@ -102,8 +102,10 @@ export default class HexMetrics extends React.Component {
       const warn = (count.idealNHex === 0 && count.nHex === 0) ?
         <i className='fa fa-exclamation-triangle' /> :
         null
+
       let className = count.deviation === 0 ? 'fade' : ''
       if (count.disable) { className += ' disabled' }
+
       return (
         <tr
           key={count.key}

--- a/source/components/HexMetrics.js
+++ b/source/components/HexMetrics.js
@@ -41,7 +41,7 @@ export default class HexMetrics extends React.Component {
     let shouldWarn = false
     const stats = this._getCountsByGeo(this.props.tiles, this.props.geos).map((d) => {
       const metric = inputHash[d.key]
-      const stat = {key: d.key, nHex: d.value}
+      const stat = {key: d.key, nHex: d.value, disable: !metric}
       if (metric) {
         const idealNHex = Math.round(metric / selectedRatio)
         if (idealNHex === 0) {
@@ -102,11 +102,13 @@ export default class HexMetrics extends React.Component {
       const warn = (count.idealNHex === 0 && count.nHex === 0) ?
         <i className='fa fa-exclamation-triangle' /> :
         null
+      let className = count.deviation === 0 ? 'fade' : ''
+      if (count.disable) { className += ' disabled' }
       return (
         <tr
           key={count.key}
           id={count.key}
-          className={count.deviation === 0 ? 'fade' : null}
+          className={className}
           onMouseOver={event => this.props.onMetricMouseOver(event.currentTarget.id)}
           onMouseOut={this.props.onMetricMouseOut}
         >
@@ -115,9 +117,9 @@ export default class HexMetrics extends React.Component {
           <td>{adjustString}</td>
           <td
             style={{cursor: 'pointer'}}
-            onMouseDown={this._mouseDown}
+            onMouseDown={count.disable ? () => {} : this._mouseDown}
           >
-            {this._drawHexagon(count.key)}
+            {count.disable ? 'No Data' : this._drawHexagon(count.key)}
           </td>
         </tr>
       )

--- a/source/css/main.scss
+++ b/source/css/main.scss
@@ -271,6 +271,10 @@ table {
       opacity: 0.3;
     }
   }
+  tr.disabled {
+    pointer-events: none;
+    opacity: 0.3;
+  }
   td {
     padding: 0.3em;
   }

--- a/source/graphics/MapGraphic.js
+++ b/source/graphics/MapGraphic.js
@@ -34,6 +34,21 @@ export default class MapGraphic extends Graphic {
 
     // compute initial cartogram
     this.updatePreProjection()
+
+    // generate basemap for topogram
+    const baseMap = this._getbaseMapTopoJson(properties)
+    this._stateFeatures = topogram(
+      baseMap.topo,
+      baseMap.geometries
+    )
+    this._precomputeBounds()
+  }
+
+  /**
+   * Returns either the original map topojson and geometries or
+   * a filtered version of the map if the data properties don't match the map.
+   */
+  _getbaseMapTopoJson(properties) {
     const baseMapTopoJson = mapResource.getTopoJson()
     let filteredTopoJson = null
     let filteredGeometries = null
@@ -48,11 +63,10 @@ export default class MapGraphic extends Graphic {
       filteredTopoJson.objects.states.geometries = filteredGeometries
     }
 
-    this._stateFeatures = topogram(
-      filteredTopoJson || baseMapTopoJson,
-      filteredGeometries || mapResource.getGeometries()
-    )
-    this._precomputeBounds()
+    return {
+      topo: filteredTopoJson || baseMapTopoJson,
+      geometries: filteredGeometries || mapResource.getGeometries(),
+    }
   }
 
   /**

--- a/source/graphics/MapGraphic.js
+++ b/source/graphics/MapGraphic.js
@@ -34,9 +34,23 @@ export default class MapGraphic extends Graphic {
 
     // compute initial cartogram
     this.updatePreProjection()
+    const baseMapTopoJson = mapResource.getTopoJson()
+    let filteredTopoJson = null
+    let filteredGeometries = null
+
+    // for custom uploads with incomplete data
+    if (properties.length !== baseMapTopoJson.objects.states.geometries.length) {
+      const statesWithData = properties.map(property => property[0])
+      filteredGeometries = baseMapTopoJson.objects.states.geometries
+        .filter(geom => statesWithData.indexOf(geom.id) > -1)
+      filteredTopoJson = JSON.parse(JSON.stringify(baseMapTopoJson)) // clones the baseMap
+      // only pass filtered geometries to topogram generator
+      filteredTopoJson.objects.states.geometries = filteredGeometries
+    }
+
     this._stateFeatures = topogram(
-      mapResource.getTopoJson(),
-      mapResource.getGeometries()
+      filteredTopoJson || baseMapTopoJson,
+      filteredGeometries || mapResource.getGeometries()
     )
     this._precomputeBounds()
   }

--- a/source/resources/DatasetResource.js
+++ b/source/resources/DatasetResource.js
@@ -34,7 +34,7 @@ class DatasetResource {
       if (!hasId) {
         badMapIds.push(row[0])
       }
-      if (row[1] <= 0 || isNaN(+row[1])) {
+      if (row[1] <= 0 || isNaN(row[1])) {
         badValueIds.push(row[0])
       }
       return hasId && row[1] > 0
@@ -56,6 +56,7 @@ class DatasetResource {
       alertString += ` Ids ${valueIdString} have zero or negative value.`
     }
     alertString += ' This data has been pruned.'
+    // eslint-disable-next-line no-alert
     alert(alertString)
   }
 

--- a/source/resources/DatasetResource.js
+++ b/source/resources/DatasetResource.js
@@ -29,7 +29,7 @@ class DatasetResource {
     const features = mapResource.getUniqueFeatureIds()
     const badMapIds = []
     const badValueIds = []
-    const parsed = csvParseRows(csv, d => [d[0], +d[1]]).filter(row => {
+    const parsed = csvParseRows(csv, d => [d[0], parseFloat(d[1])]).filter(row => {
       const hasId = features.indexOf(row[0]) > -1
       if (!hasId) {
         badMapIds.push(row[0])

--- a/source/resources/DatasetResource.js
+++ b/source/resources/DatasetResource.js
@@ -1,5 +1,7 @@
 import {csvParseRows} from 'd3-dsv'
 
+import mapResource from './MapResource'
+
 import populationCsv from '../../data/population-by-state.csv'
 import electoralCollegeCsv from '../../data/electoral-college-votes-by-state.csv'
 import gdpCsv from '../../data/gdp-by-state.csv'
@@ -24,7 +26,26 @@ class DatasetResource {
   }
 
   parseCsv(csv) {
-    return csvParseRows(csv, d => [d[0], +d[1]])
+    const features = mapResource.getUniqueFeatureIds()
+    const missingIds = []
+    const parsed = csvParseRows(csv, d => [d[0], +d[1]]).filter(row => {
+      const hasId = features.indexOf(row[0]) > -1
+      if (!hasId) {
+        missingIds.push(row[0])
+      }
+      return hasId
+    })
+    if (missingIds.length) {
+      this._warnMissing(missingIds)
+    }
+    return parsed
+  }
+
+  _warnMissing(missingIds) {
+    const idString = missingIds.join(',')
+    let alertString = `There is no associated map data associated with id(s): ${idString}.`
+    alertString += ' This data has been pruned.'
+    alert(alertString)
   }
 
   getLabels() {


### PR DESCRIPTION
• Handles geos with 0, negative, or NaN by warning the user, then removing from data. In order to make the cartogram work, we remove it from the map geometry before calling the cartogram.
• Handles extra geos (fips for places we don't have or non-existent fips) by warning the user and removing from data. This fixes a bug where bad fips codes wouldn't throw an error, but would mess up the metric calculations.

Attached image shows cartogram with no Alabama or California.
![screen shot 2016-10-12 at 3 12 55 pm](https://cloud.githubusercontent.com/assets/5199515/19329599/71285884-908e-11e6-8d78-fe1e22ee3577.png)
