### PR TITLE
allow dismissal of mobile modal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import MobileDetect from 'mobile-detect'
 import canvas from './source/Canvas'
 import ui from './source/Ui'
 import metrics from './source/Metrics'
@@ -18,6 +19,14 @@ const CARTOGRAM_COMPUTE_FPS = 60.0
 let cartogramComputeTimer
 
 let importing = false
+
+if (typeof window !== 'undefined') {
+  const mobileDetect = new MobileDetect(window.navigator.userAgent)
+  const isMobile = mobileDetect.mobile()
+  if (isMobile) {
+    document.body.className = 'isMobile'
+  }
+}
 
 function selectDataset(dataset) {
   importing = false

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "density-clustering": "^1.3.0",
     "font-awesome": "^4.6.3",
     "hull.js": "^0.2.10",
+    "mobile-detect": "^1.3.5",
     "point-in-polygon": "^1.0.1",
     "polygon-overlap": "^1.0.5",
     "react": "^15.3.1",

--- a/source/Ui.js
+++ b/source/Ui.js
@@ -35,6 +35,11 @@ class Ui {
     this._toggleManual = this._toggleManual.bind(this)
     this._updateNErrors = this._updateNErrors.bind(this)
     this._toggleRefineTooltip = this._toggleRefineTooltip.bind(this)
+    this._closeMobile = this._closeMobile.bind(this)
+  }
+
+  _closeMobile() {
+    document.body.className = ''
   }
 
   setGeos(geos) {
@@ -275,6 +280,10 @@ class Ui {
         <div className='mobile-redirect'>
           <div className='background'>
             <div className='main'>
+              <div
+                className='close-mobile'
+                onClick={this._closeMobile}
+              >&#215;</div>
               <h1>TILEGRAMS</h1>
               <img src={tilegramsLogo} className='tilegrams-logo' alt='Tilegrams' />
               <h2>Create tiled maps where regions are sized proportionally to a dataset.</h2>

--- a/source/constants.js
+++ b/source/constants.js
@@ -6,10 +6,14 @@ const canvasDimensions = {
   width: 0,
   height: 0,
 }
+/**
+ * update canvasDimensions ensuring that there is always a min w/h
+ * prevent errors on small screens
+ */
 function updateCanvasSize() {
   const canvasContainer = document.getElementById('canvas')
-  canvasDimensions.width = canvasContainer.offsetWidth * devicePixelRatio
-  canvasDimensions.height = canvasContainer.offsetHeight * devicePixelRatio
+  canvasDimensions.width = Math.max(200, canvasContainer.offsetWidth * devicePixelRatio)
+  canvasDimensions.height = Math.max(200, canvasContainer.offsetHeight * devicePixelRatio)
 }
 
 /**

--- a/source/css/mobile.scss
+++ b/source/css/mobile.scss
@@ -2,24 +2,10 @@
   display: none;
 }
 
-// https://css-tricks.com/snippets/css/media-queries-for-standard-devices/
-@media
-only screen and (min-device-width: 320px) and (max-device-width: 480px) and (-webkit-min-device-pixel-ratio: 2), // iPhone4
-only screen and (min-device-width: 320px) and (max-device-width: 568px) and (-webkit-min-device-pixel-ratio: 2), // iPhone5
-only screen and (min-device-width: 375px) and (max-device-width: 667px) and (-webkit-min-device-pixel-ratio: 2), // iPhone6
-only screen and (min-device-width: 414px) and (max-device-width: 736px) and (-webkit-min-device-pixel-ratio: 3), // iPhone6+
-screen and (device-width: 320px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 2), // galaxyS3
-screen and (device-width: 320px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3), // galaxyS4
-screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3), // galaxyS5 / HTC
-only screen and (min-device-width: 768px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 1), // iPad mini, 1, 2
-only screen and (min-device-width: 768px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2), // iPad 3,4
-(min-device-width: 800px) and (max-device-width: 1280px), //galaxy tablets
-screen and (device-width: 601px) and (device-height: 906px) and (-webkit-min-device-pixel-ratio: 1.331) and (-webkit-max-device-pixel-ratio: 1.332) //nexus tablets
-{
-  body {
-    overflow-x: hidden;
-    overflow-y: hidden;
-  }
+//mobile styles
+body.isMobile {
+  overflow-x: hidden;
+  overflow-y: hidden;
   .credits {
     z-index: 100;
     padding: 15px;
@@ -29,7 +15,6 @@ screen and (device-width: 601px) and (device-height: 906px) and (-webkit-min-dev
     right: 0;
     bottom: 0;
     text-align: center;
-    font-size: 1.2em;
     line-height: 1.4em;
     .source {
       display: none;
@@ -50,6 +35,12 @@ screen and (device-width: 601px) and (device-height: 906px) and (-webkit-min-dev
       width: 100%;
       height: 100%;
       background-color: rgba(0,0,0,0.7);
+    }
+    .close-mobile {
+      position: absolute;
+      top: 30px;
+      right: 30px;
+      font-size: 30px;
     }
     .tilegrams-logo {
       width: 2em;


### PR DESCRIPTION
Fix for issue of mobile media queries falsely triggering the "visit on desktop" modal. This uses User-Agent string to detect if is a phone or tablet and then triggers the modal. Because User-Agent queries are possibly unreliable, it also adds a button to close the modal. Included in this PR is a fix for small screens where canvases with very small or 0 dimensions triggered errors on every frame.