### PR TITLE
Make project accesible in 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ or the [manual](MANUAL.md).
 ## Development
 
 ### Setup
+Despite many deprecations, npm v10.24.1 can install this project when it can call python2 (Python 2.7). Other setups might work.
 
 After cloning the repository, run:
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "stats-js": "^1.0.0-alpha1",
-    "topogram": "git://github.com/PitchInteractiveInc/topogram.git#node-js",
+    "topogram": "https://github.com/PitchInteractiveInc/topogram.git#node-js",
     "topojson": "^1.6.26"
   }
 }


### PR DESCRIPTION
Change package.json to avoid deprecated git:// protocol. Add hint to use older npm and python versions.

Github blocks git:// requests, thereby stopping installation.
Fix by changing to https protocol for one dependency in package.json.

Current npm version do not install the project for unknown reason. 
Fix by falling back to an older npm version.
Add hint for new users to make the project install out of the box. 